### PR TITLE
Add the gif to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 *.mov
+*.gif
 benchmarks
 test
 src


### PR DESCRIPTION
The `flow-demo.gif` gif is included in the published bundle, but it probably shouldn't be.