### PR TITLE
Use `files` field in package.json instead of `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-*.mov
-*.gif
-benchmarks
-test
-src

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "plugin",
     "errors"
   ],
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.15.0",
     "flow-bin": "^0.33.0",


### PR DESCRIPTION
Fixes #29.

Please check that I'm not forgetting any files. The problem with using `files`, is that if you're forgetting a file, your package will be broken (though you'll probably notice it quickly and fix it it in the next release), whereas with `.npmignore`, if you're forgetting a file then you're just shipping extra content.

Anyway, if this contains everything, then the package will be lighter for a long time :)
As a side-note, the size could be reduced even more by removing the root index.js and by making the `main` field of the package.json link directly to `dist/index.js`.

Let me know if you have any questions or feedback :)