### PR TITLE
Add failing test case for `property not found` errors across files

### DIFF
--- a/test/8.example.js
+++ b/test/8.example.js
@@ -1,0 +1,9 @@
+/* eslint-disable */
+/**
+ * @flow
+ */
+import { foo } from './6.example.js';
+
+foo(1234);
+
+foo({xyz: 'abc'});

--- a/test/8.expect.js
+++ b/test/8.expect.js
@@ -1,0 +1,38 @@
+export default [
+  {
+    end: 7,
+    loc: {
+      end: {
+        column: 8,
+        line: 7,
+        offset: 85
+      },
+      start: {
+        column: 5,
+        line: 7,
+        offset: 81
+      }
+    },
+    message: "number:  This type is incompatible with 'object type'. See ./test/6.example.js: 5",
+    start: 7,
+    type: 'default'
+  },
+  {
+    end: 9,
+    loc: {
+      end: {
+        column: 38,
+        line: 9,
+        offset: 50
+      },
+      start: {
+        column: 26,
+        line: 9,
+        offset: 37
+      }
+    },
+    message: "property `baz`:  Property not found in 'object literal'. See ./test/6.example.js: 5",
+    start: 9,
+    type: 'default'
+  }
+];

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -12,7 +12,8 @@ const testFilenames = [
   '4.example.js',
   '5.example.js',
   '6.example.js',
-  '7.example.js'
+  '7.example.js',
+  '8.example.js'
 ];
 
 const testResults = testFilenames.map((filename, index) => {


### PR DESCRIPTION
For #33 
