### PR TITLE
Improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/codebases/**

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,4 @@
 lib-cov
 coverage
 dist
-node_modules
 test/codebases/**

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,6 @@
+.npm
+lib-cov
+coverage
+dist
+node_modules
 test/codebases/**

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "index.js",
   "scripts": {
     "build": "cross-env NODE_ENV=production babel src --out-dir dist",
-    "lint": "eslint --ignore-path .gitignore --ignore-pattern test/codebases/** --cache --format=node_modules/eslint-formatter-pretty .",
+    "lint": "eslint --cache --format=node_modules/eslint-formatter-pretty .",
     "preversion": "npm run build",
     "spec": "npm run build && jest test/format.spec.js",
     "test": "npm run lint && npm run spec"

--- a/src/collect.js
+++ b/src/collect.js
@@ -182,6 +182,6 @@ function executeFlow(stdin, root, filepath) {
     : true;
 }
 
-export default function Collect(stdin, root, filepath) {
-  return executeFlow(stdin, root, filepath, {});
+export default function collect(stdin, root, filepath) {
+  return executeFlow(stdin, root, filepath);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,17 +6,7 @@ import collect from './collect';
 let runOnAllFiles;
 
 function hasFlowPragma(source) {
-  let has = false;
-  const comments = source.getAllComments();
-
-  for (let i = 0; i < comments.length; i += 1) {
-    if (/@flow/.test(comments[i].value)) {
-      has = true;
-      break;
-    }
-  }
-
-  return has;
+  return source.getAllComments().some(comment => /@flow/.test(comment.value));
 }
 
 export default {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,9 @@ import collect from './collect';
 let runOnAllFiles;
 
 function hasFlowPragma(source) {
-  return source.getAllComments().some(comment => /@flow/.test(comment.value));
+  return source
+    .getAllComments()
+    .some(comment => /@flow/.test(comment.value));
 }
 
 export default {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,20 @@ import collect from './collect';
 
 let runOnAllFiles;
 
+function hasFlowPragma(source) {
+  let has = false;
+  const comments = source.getAllComments();
+
+  for (let i = 0; i < comments.length; i += 1) {
+    if (/@flow/.test(comments[i].value)) {
+      has = true;
+      break;
+    }
+  }
+
+  return has;
+}
+
 export default {
   rules: {
     'show-errors': function showErrors(context) {
@@ -14,7 +28,7 @@ export default {
           let collected;
 
           if (onTheFly) {
-            const stdin = context.getSourceCode().getText();
+            const source = context.getSourceCode();
             const root = process.cwd();
 
             // Check to see if we should run on every file
@@ -29,16 +43,11 @@ export default {
               }
             }
 
-            if (stdin) {
-              if (runOnAllFiles === false) {
-                // `String.prototype.includes` is an O(n) operation :(
-                if (!stdin.includes('@flow')) {
-                  return true;
-                }
-              }
+            if (runOnAllFiles === false && !hasFlowPragma(source)) {
+              return true;
             }
 
-            collected = collect(stdin, root, context.getFilename());
+            collected = collect(source.getText(), root, context.getFilename());
           } else {
             collected = collect();
           }

--- a/test/__snapshots__/format.spec.js.snap
+++ b/test/__snapshots__/format.spec.js.snap
@@ -1,3 +1,5 @@
+exports[`Check codebases no-flow-pragma - eslint should give expected output 1`] = `""`;
+
 exports[`Check codebases project-1 - eslint should give expected output 1`] = `
 "
 ./1.example.js

--- a/test/__snapshots__/format.spec.js.snap
+++ b/test/__snapshots__/format.spec.js.snap
@@ -43,3 +43,15 @@ exports[`Check codebases project-1 - eslint should give expected output 1`] = `
 
 "
 `;
+
+exports[`Check codebases run-all - eslint should give expected output 1`] = `
+"
+./example.js
+   2:11  error  string:  This type is incompatible with the expected return type of \'boolean\'. See line 1  flowtype-errors/show-errors
+   5:7   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
+  12:15  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+
+✖ 3 problems (3 errors, 0 warnings)
+
+"
+`;

--- a/test/__snapshots__/format.spec.js.snap
+++ b/test/__snapshots__/format.spec.js.snap
@@ -1,3 +1,27 @@
+exports[`Check codebases flow-pragma-1 - eslint should give expected output 1`] = `
+"
+./example.js
+   4:11  error  string:  This type is incompatible with the expected return type of \'boolean\'. See line 3  flowtype-errors/show-errors
+   7:7   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
+  14:15  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+
+✖ 3 problems (3 errors, 0 warnings)
+
+"
+`;
+
+exports[`Check codebases flow-pragma-2 - eslint should give expected output 1`] = `
+"
+./example.js
+   6:11  error  string:  This type is incompatible with the expected return type of \'boolean\'. See line 5  flowtype-errors/show-errors
+   9:7   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
+  16:15  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+
+✖ 3 problems (3 errors, 0 warnings)
+
+"
+`;
+
 exports[`Check codebases no-flow-pragma - eslint should give expected output 1`] = `""`;
 
 exports[`Check codebases project-1 - eslint should give expected output 1`] = `

--- a/test/codebases/flow-pragma-1/example.js
+++ b/test/codebases/flow-pragma-1/example.js
@@ -1,0 +1,15 @@
+// @flow
+
+function test(x: string): boolean {
+  return 'string';
+}
+
+test(x);
+
+function square(x): number {
+  return x * x;
+}
+
+function incorrectSquare(x): number {
+  return x * 'x';
+}

--- a/test/codebases/flow-pragma-2/example.js
+++ b/test/codebases/flow-pragma-2/example.js
@@ -1,0 +1,17 @@
+/**
+ * @flow
+ */
+
+function test(x: string): boolean {
+  return 'string';
+}
+
+test(x);
+
+function square(x): number {
+  return x * x;
+}
+
+function incorrectSquare(x): number {
+  return x * 'x';
+}

--- a/test/codebases/no-flow-pragma/example.js
+++ b/test/codebases/no-flow-pragma/example.js
@@ -1,0 +1,13 @@
+function test(x: string): boolean {
+  return 'string';
+}
+
+test(x);
+
+function square(x): number {
+  return x * x;
+}
+
+function incorrectSquare(x): number {
+  return x * 'x';
+}

--- a/test/codebases/run-all/.flowconfig
+++ b/test/codebases/run-all/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+all=true

--- a/test/codebases/run-all/example.js
+++ b/test/codebases/run-all/example.js
@@ -1,0 +1,13 @@
+function test(x: string): boolean {
+  return 'string';
+}
+
+test(x);
+
+function square(x): number {
+  return x * x;
+}
+
+function incorrectSquare(x): number {
+  return x * 'x';
+}

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -64,6 +64,8 @@ function runEslint(cwd) {
 }
 
 const codebases = [
+  'flow-pragma-1',
+  'flow-pragma-2',
   'no-flow-pragma',
   'project-1',
   'run-all'

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect as chaiExpect } from 'chai';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { sync as spawnSync } from 'cross-spawn';
 import collect from '../src/collect';
 
@@ -98,9 +98,10 @@ describe('Check codebases', () => {
   for (const folder of codebases) {
     it(`${folder} - eslint should give expected output`, () => {
       const fullFolder = path.resolve(`./test/codebases/${folder}`);
+      const configPath = path.resolve(fullFolder, '.eslintrc.js');
 
       // Write config file
-      writeFileSync(path.resolve(fullFolder, '.eslintrc.js'), eslintConfig);
+      writeFileSync(configPath, eslintConfig);
 
       // Spawn a eslint process
       const { stdout, stderr } = runEslint(fullFolder);
@@ -111,6 +112,9 @@ describe('Check codebases', () => {
       expect(stdout.replace(regexp, match => match.replace(fullFolder, '.').replace(/\\/g, '/'))).toMatchSnapshot();
 
       expect(stderr).toEqual('');
+
+      // Clean up
+      unlinkSync(configPath);
     });
   }
 });

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -65,7 +65,8 @@ function runEslint(cwd) {
 
 const codebases = [
   'no-flow-pragma',
-  'project-1'
+  'project-1',
+  'run-all'
 ];
 
 const eslintConfig = `

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -64,6 +64,7 @@ function runEslint(cwd) {
 }
 
 const codebases = [
+  'no-flow-pragma',
   'project-1'
 ];
 


### PR DESCRIPTION
I decided to use the `getAllComments` function to find the existence of a `@flow` comment. It should be faster than to use `.includes()` in the whole file.

I also added some tests to make sure flow is only run on files with `@flow`, except if `all=true` exists in `.flowconfig`.

Also added a `.eslintignore` file with `test/codebases/**` to prevent code editors from trying to lint the test files (my editor was giving an error since `../../../dist/index.js` does not exist from the project folder).

Edit: I don't understand why the lint task works on Windows, but fails on Travis... I will take a look.

Edit 2: Fixed [here](https://github.com/amilajack/eslint-plugin-flowtype-errors/pull/77/commits/3cd9d8b68b85028592337b18ee3d20b5d4ae5846). Using `.eslintignore` and `--ignore-path` together seems to cause problems in UNIX.