### PR TITLE
Fix reported column number in ESLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Fixed off-by-one error in reported column numbers.
 
+## v3.3.1
+
+- No interesting changes.
+
+## v3.3.0
+
 ### Added
 
 - Added `enforce-min-coverage` rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Master
 
+### Fixed
+
+- Fixed off-by-one error in reported column numbers.
+
+### Added
+
 - Added `enforce-min-coverage` rule.
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,6 @@ http://eslint.org/docs/user-guide/integrations#editors
 ## Planned Implementations
 * Add more extensive tests
 * Allow passing arguments to flow binary
-* Fix column number inconsistencies between ESLint and Flow
 * Run flow minimal amount of times for faster linting
 * Custom formatting of flow error messages
 * Enable rules to allow and disallow specific flow errors

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,16 @@ export default {
 
           collected.forEach(({ loc, message }) => {
             context.report({
-              loc,
+              loc: loc
+                ? {
+                  ...loc,
+                  start: {
+                    ...loc.start,
+                    // Flow's column numbers are 1-based, while ESLint's are 0-based.
+                    column: loc.start.column - 1
+                  }
+                }
+                : loc,
               message
             });
           });

--- a/test/__snapshots__/format.spec.js.snap
+++ b/test/__snapshots__/format.spec.js.snap
@@ -27,9 +27,9 @@ exports[`Check codebases coverage-ok2 - eslint should give expected output 1`] =
 exports[`Check codebases flow-pragma-1 - eslint should give expected output 1`] = `
 "
 ./example.js
-   4:11  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 3  flowtype-errors/show-errors
-   7:7   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
-  14:15  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+   4:10  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 3  flowtype-errors/show-errors
+   7:6   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
+  14:14  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
 
 ✖ 3 problems (3 errors, 0 warnings)
 
@@ -39,9 +39,9 @@ exports[`Check codebases flow-pragma-1 - eslint should give expected output 1`] 
 exports[`Check codebases flow-pragma-2 - eslint should give expected output 1`] = `
 "
 ./example.js
-   6:11  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 5  flowtype-errors/show-errors
-   9:7   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
-  16:15  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+   6:10  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 5  flowtype-errors/show-errors
+   9:6   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
+  16:14  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
 
 ✖ 3 problems (3 errors, 0 warnings)
 
@@ -55,42 +55,42 @@ exports[`Check codebases no-flow-pragma - eslint should give expected output 1`]
 exports[`Check codebases project-1 - eslint should give expected output 1`] = `
 "
 ./1.example.js
-   5:11  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 4  flowtype-errors/show-errors
-   8:7   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
-  15:15  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+   5:10  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 4  flowtype-errors/show-errors
+   8:6   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
+  15:14  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
 
 ./2.example.js
-   8:25  error  parameter \`x\`:  Missing annotation       flowtype-errors/show-errors
-  12:7   error  identifier \`x\`:  Could not resolve name  flowtype-errors/show-errors
+   8:24  error  parameter \`x\`:  Missing annotation       flowtype-errors/show-errors
+  12:6   error  identifier \`x\`:  Could not resolve name  flowtype-errors/show-errors
 
 ./3.example.js
-   9:11  error  string:  This type is incompatible with the expected return type of 'number'. See line 8   flowtype-errors/show-errors
-  13:11  error  string:  This type is incompatible with the expected return type of 'number'. See line 12  flowtype-errors/show-errors
-  16:20  error  string:  This type is incompatible with 'number'. See line 16                              flowtype-errors/show-errors
-  18:8   error  who:  name is already bound 'function who'. See line 12                                    flowtype-errors/show-errors
-  20:6   error  unused function argument:                                                                  flowtype-errors/show-errors
-  20:12  error  function:  This type cannot be added to 'number'. See line 20                              flowtype-errors/show-errors
+   9:10  error  string:  This type is incompatible with the expected return type of 'number'. See line 8   flowtype-errors/show-errors
+  13:10  error  string:  This type is incompatible with the expected return type of 'number'. See line 12  flowtype-errors/show-errors
+  16:19  error  string:  This type is incompatible with 'number'. See line 16                              flowtype-errors/show-errors
+  18:7   error  who:  name is already bound 'function who'. See line 12                                    flowtype-errors/show-errors
+  20:5   error  unused function argument:                                                                  flowtype-errors/show-errors
+  20:11  error  function:  This type cannot be added to 'number'. See line 20                              flowtype-errors/show-errors
 
 ./4.example.js
-   8:11  error  property \`lastName\`:  Property not found in 'props of React element \`Foo\`'. See line 24  flowtype-errors/show-errors
-  24:13  error  props of React element \`Foo\`:  This type is incompatible with 'object type'. See line 8  flowtype-errors/show-errors
+   8:10  error  property \`lastName\`:  Property not found in 'props of React element \`Foo\`'. See line 24  flowtype-errors/show-errors
+  24:12  error  props of React element \`Foo\`:  This type is incompatible with 'object type'. See line 8  flowtype-errors/show-errors
 
 ./5.example.js
-  8:4  error  string:  This type is incompatible with the expected param type of 'number'. See line 4  flowtype-errors/show-errors
+  8:3  error  string:  This type is incompatible with the expected param type of 'number'. See line 4  flowtype-errors/show-errors
 
 ./6.example.js
-   8:6  error  number:  This type is incompatible with the expected param type of 'object type'. See line 4       flowtype-errors/show-errors
-  10:2  error  function call:  'property \`baz\`'. See line 4. Property not found in 'object literal'. See line 10  flowtype-errors/show-errors
+   8:5  error  number:  This type is incompatible with the expected param type of 'object type'. See line 4       flowtype-errors/show-errors
+  10:1  error  function call:  'property \`baz\`'. See line 4. Property not found in 'object literal'. See line 10  flowtype-errors/show-errors
 
 ./7.example.js
-  6:4  error  string:  This type is incompatible with the expected param type of 'number'. See ./5.example.js:4  flowtype-errors/show-errors
+  6:3  error  string:  This type is incompatible with the expected param type of 'number'. See ./5.example.js:4  flowtype-errors/show-errors
 
 ./8.example.js
-  6:6  error  number:  This type is incompatible with the expected param type of 'object type'. See ./6.example.js:4      flowtype-errors/show-errors
-  8:2  error  function call:  'property \`baz\`'. See ./6.example.js:4. Property not found in 'object literal'. See line 8  flowtype-errors/show-errors
+  6:5  error  number:  This type is incompatible with the expected param type of 'object type'. See ./6.example.js:4      flowtype-errors/show-errors
+  8:1  error  function call:  'property \`baz\`'. See ./6.example.js:4. Property not found in 'object literal'. See line 8  flowtype-errors/show-errors
 
 ./9.example.js
-  8:18  error  React element \`Hello\`:  'property \`name\`'. See ./9.example.import.js:6. Property not found in 'props of React element \`Hello\`'. See line 8  flowtype-errors/show-errors
+  8:17  error  React element \`Hello\`:  'property \`name\`'. See ./9.example.import.js:6. Property not found in 'props of React element \`Hello\`'. See line 8  flowtype-errors/show-errors
 
 ✖ 20 problems (20 errors, 0 warnings)
 
@@ -100,9 +100,9 @@ exports[`Check codebases project-1 - eslint should give expected output 1`] = `
 exports[`Check codebases run-all - eslint should give expected output 1`] = `
 "
 ./example.js
-   2:11  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 1  flowtype-errors/show-errors
-   5:7   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
-  12:15  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+   2:10  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 1  flowtype-errors/show-errors
+   5:6   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
+  12:14  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
 
 ✖ 3 problems (3 errors, 0 warnings)
 
@@ -112,9 +112,9 @@ exports[`Check codebases run-all - eslint should give expected output 1`] = `
 exports[`Check codebases run-all-flowdir - eslint should give expected output 1`] = `
 "
 ./subdir/example.js
-   2:11  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 1  flowtype-errors/show-errors
-   5:7   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
-  12:15  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+   2:10  error  string:  This type is incompatible with the expected return type of 'boolean'. See line 1  flowtype-errors/show-errors
+   5:6   error  identifier \`x\`:  Could not resolve name                                                    flowtype-errors/show-errors
+  12:14  error  string:  The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
 
 ✖ 3 problems (3 errors, 0 warnings)
 


### PR DESCRIPTION
## Before

![screenshot from 2017-09-23 14-19-27](https://user-images.githubusercontent.com/2142817/30773108-5930cb3e-a06a-11e7-8a8f-42f3bce90249.png)

## After

![screenshot from 2017-09-23 14-18-37](https://user-images.githubusercontent.com/2142817/30773113-66de242a-a06a-11e7-96fb-4c7bbf6a449e.png)


## Commit message

ESLint's column numbers are 0-based:
https://eslint.org/docs/developer-guide/working-with-rules#contextreport

> column - the 0-based column number at which the problem occurred.

Flow's column numbers are 1-based:

    $ cat index.js
    // @flow
    // The next line has an error at the first column: "abc" is not defined.
    abc

    $ flow check-contents < index.js --json --root index.js | jq '.errors[] | .message[] | .loc'
    {
      "source": "-",
      "type": "SourceFile",
      "start": {
        "line": 3,
        "column": 1,
        "offset": 82
      },
      "end": {
        "line": 3,
        "column": 3,
        "offset": 85
      }
    }

This commit simply subtracts the start column by 1.

Before:

    $ eslint index.js --format codeframe
    error: identifier `abc`:  Could not resolve name (flowtype-errors/show-errors) at index.js:3:2:
      1 | // @flow
      2 | // The next line has an error at the first column: "abc" is not defined.
    > 3 | abc
        |  ^
      4 |

    1 error found.

After:

    $ eslint index.js --format codeframe
    error: identifier `abc`:  Could not resolve name (flowtype-errors/show-errors) at index.js:3:1:
      1 | // @flow
      2 | // The next line has an error at the first column: "abc" is not defined.
    > 3 | abc
        | ^
      4 |

    1 error found.

Shouldn't the end column be subtracted by 1 as well? It seems like
ESLint's end column is exclusive, while Flow's is inclusive. So the
end column should stay unchanged. I tested this by using the
linter-eslint plugin in the Atom editor. When subtracting 1 from the end
column only "ab" of "abc" in index.js above is underlined as an error.
When keeping the end column the entire word "abc" is underlined (which
is the desired result). Here you can see what it looks like if 1 is subtracted from the end as well:

![screenshot from 2017-09-23 14-23-13](https://user-images.githubusercontent.com/2142817/30773134-c46f5f3c-a06a-11e7-88b9-d26fe3aef3a7.png)


I have consistently noted that the error locations are off-by-one after
having used eslint-plugin-flowtype-errors for several months, should it
should be safe to always simply subtract 1 from the start column.