### PR TITLE
Update to Flow 0.57.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,13 +58,13 @@
     "eslint-nibble-ignore": "^3.0.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-prettier": "^2.3.1",
-    "flow-bin": "^0.55.0",
+    "flow-bin": "^0.57.3",
     "jest-cli": "^21.1.0",
     "regenerator-runtime": "^0.11.0"
   },
   "peerDependencies": {
     "eslint": ">=4.0.0",
-    "flow-bin": "^0.55.0"
+    "flow-bin": "^0.57.3"
   },
   "engines": {
     "node": ">=4.x",

--- a/test/__snapshots__/format.spec.js.snap
+++ b/test/__snapshots__/format.spec.js.snap
@@ -68,31 +68,32 @@ exports[`Check codebases project-1 - eslint should give expected output 1`] = `
   13:10  error  string:  This type is incompatible with the expected return type of 'number'. See line 12  flowtype-errors/show-errors
   16:19  error  string:  This type is incompatible with 'number'. See line 16                              flowtype-errors/show-errors
   18:7   error  who:  name is already bound 'function who'. See line 12                                    flowtype-errors/show-errors
-  20:5   error  unused function argument:                                                                  flowtype-errors/show-errors
+  20:5   error  function expects no arguments:                                                             flowtype-errors/show-errors
   20:11  error  function:  This type cannot be added to 'number'. See line 20                              flowtype-errors/show-errors
 
 ./4.example.js
-  11:29  error  property \`lastName\`:  Property not found in 'props of React element \`Foo\`'. See line 27   flowtype-errors/show-errors
-  27:12  error  props of React element \`Foo\`:  This type is incompatible with 'object type'. See line 11  flowtype-errors/show-errors
+  27:12  error  Property \`firstName\` is incompatible:  'string'. See line 27. This type is incompatible with 'object type'. See line 7  flowtype-errors/show-errors
+  27:12  error  Property \`lastName\` is incompatible:   See line 11. Property not found in 'props of React element \`Foo\`'. See line 27   flowtype-errors/show-errors
 
 ./5.example.js
   8:3  error  string:  This type is incompatible with the expected param type of 'number'. See line 4  flowtype-errors/show-errors
 
 ./6.example.js
    8:5  error  number:  This type is incompatible with the expected param type of 'object type'. See line 4       flowtype-errors/show-errors
-  10:1  error  function call:  'property \`baz\`'. See line 4. Property not found in 'object literal'. See line 10  flowtype-errors/show-errors
+  10:5  error  Property \`baz\` is incompatible:   See line 4. Property not found in 'object literal'. See line 10  flowtype-errors/show-errors
 
 ./7.example.js
   6:3  error  string:  This type is incompatible with the expected param type of 'number'. See ./5.example.js:4  flowtype-errors/show-errors
 
 ./8.example.js
   6:5  error  number:  This type is incompatible with the expected param type of 'object type'. See ./6.example.js:4      flowtype-errors/show-errors
-  8:1  error  function call:  'property \`baz\`'. See ./6.example.js:4. Property not found in 'object literal'. See line 8  flowtype-errors/show-errors
+  8:5  error  Property \`baz\` is incompatible:   See ./6.example.js:4. Property not found in 'object literal'. See line 8  flowtype-errors/show-errors
 
 ./9.example.js
-  8:17  error  React element \`Hello\`:  'property \`name\`'. See ./9.example.import.js:6. Property not found in 'props of React element \`Hello\`'. See line 8  flowtype-errors/show-errors
+  8:17  error  Property \`name\` is incompatible:   See ./9.example.import.js:6. Property not found in 'props of React element \`Hello\`'. See line 8                  flowtype-errors/show-errors
+  8:28  error  null:  This type is incompatible with the expected param type of 'Element'. See https://github.com/facebook/flow/blob/v0.57.3/lib/react-dom.js#L17  flowtype-errors/show-errors
 
-✖ 20 problems (20 errors, 0 warnings)
+✖ 21 problems (21 errors, 0 warnings)
 
 "
 `;
@@ -309,7 +310,7 @@ Array [
         "offset": 268,
       },
     },
-    "message": "unused function argument: ",
+    "message": "function expects no arguments: ",
     "start": 21,
     "type": "default",
   },
@@ -337,21 +338,21 @@ Array [
 exports[`Format 4.example.js - should have expected properties 1`] = `
 Array [
   Object {
-    "end": 12,
+    "end": 28,
     "loc": Object {
       "end": Object {
-        "column": 33,
-        "line": 12,
-        "offset": 173,
+        "column": 35,
+        "line": 28,
+        "offset": 451,
       },
       "start": Object {
-        "column": 29,
-        "line": 12,
-        "offset": 168,
+        "column": 12,
+        "line": 28,
+        "offset": 427,
       },
     },
-    "message": "property \`lastName\`:  Property not found in 'props of React element \`Foo\`'. See line 28",
-    "start": 12,
+    "message": "Property \`firstName\` is incompatible:  'string'. See line 28. This type is incompatible with 'object type'. See line 8",
+    "start": 28,
     "type": "default",
   },
   Object {
@@ -368,7 +369,7 @@ Array [
         "offset": 427,
       },
     },
-    "message": "props of React element \`Foo\`:  This type is incompatible with 'object type'. See line 12",
+    "message": "Property \`lastName\` is incompatible:   See line 12. Property not found in 'props of React element \`Foo\`'. See line 28",
     "start": 28,
     "type": "default",
   },
@@ -422,17 +423,17 @@ Array [
     "end": 11,
     "loc": Object {
       "end": Object {
-        "column": 19,
+        "column": 18,
         "line": 11,
-        "offset": 136,
+        "offset": 135,
       },
       "start": Object {
-        "column": 1,
+        "column": 5,
         "line": 11,
-        "offset": 117,
+        "offset": 121,
       },
     },
-    "message": "function call:  'property \`baz\`'. See line 5. Property not found in 'object literal'. See line 11",
+    "message": "Property \`baz\` is incompatible:   See line 5. Property not found in 'object literal'. See line 11",
     "start": 11,
     "type": "default",
   },
@@ -486,17 +487,17 @@ Array [
     "end": 9,
     "loc": Object {
       "end": Object {
-        "column": 19,
+        "column": 18,
         "line": 9,
-        "offset": 108,
+        "offset": 107,
       },
       "start": Object {
-        "column": 1,
+        "column": 5,
         "line": 9,
-        "offset": 89,
+        "offset": 93,
       },
     },
-    "message": "function call:  'property \`baz\`'. See ./6.example.js:5. Property not found in 'object literal'. See line 9",
+    "message": "Property \`baz\` is incompatible:   See ./6.example.js:5. Property not found in 'object literal'. See line 9",
     "start": 9,
     "type": "default",
   },
@@ -519,7 +520,25 @@ Array [
         "offset": 159,
       },
     },
-    "message": "React element \`Hello\`:  'property \`name\`'. See ./9.example.import.js:7. Property not found in 'props of React element \`Hello\`'. See line 9",
+    "message": "Property \`name\` is incompatible:   See ./9.example.import.js:7. Property not found in 'props of React element \`Hello\`'. See line 9",
+    "start": 9,
+    "type": "default",
+  },
+  Object {
+    "end": 9,
+    "loc": Object {
+      "end": Object {
+        "column": 57,
+        "line": 9,
+        "offset": 200,
+      },
+      "start": Object {
+        "column": 28,
+        "line": 9,
+        "offset": 170,
+      },
+    },
+    "message": "null:  This type is incompatible with the expected param type of 'Element'. See https://github.com/facebook/flow/blob/v0.57.3/lib/react-dom.js#L17",
     "start": 9,
     "type": "default",
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,9 +1959,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.55.0:
-  version "0.55.0"
-  resolved "https://registry.npmjs.org/flow-bin/-/flow-bin-0.55.0.tgz#9083da9327bd8cab6b4076d63d85f2247a7eae1b"
+flow-bin@^0.57.3:
+  version "0.57.3"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Flow now puts more direct error messages in an `extra` property. This PR uses those messages when they're available.

Flow v0.57 also errors in more cases, so now one of the test cases has a new error that references a built-in Flow lib definition. This PR references the built-in definition by providing a link to the definition on GitHub (instead of the random, temporary file that Flow creates for the definition).