### PR TITLE
Add support for vue and html files

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chai": "^4.1.2",
     "cross-env": "^5.1.1",
     "cross-spawn": "^5.1.0",
-    "eslint": "4.12.1",
+    "eslint": "^4.15.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-formatter-pretty": "^1.3.0",
@@ -63,7 +63,8 @@
     "flow-bin": "^0.60.1",
     "jest-cli": "^21.2.1",
     "prettier": "^1.9.1",
-    "regenerator-runtime": "^0.11.0"
+    "regenerator-runtime": "^0.11.0",
+    "vue-eslint-parser": "^2.0.2"
   },
   "peerDependencies": {
     "eslint": ">=4.0.0",

--- a/src/context.js
+++ b/src/context.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+export type EslintContext = {
+  getAllComments: Function,
+  getFilename: Function,
+  getSourceCode: Function,
+  report: Function,
+  settings: ?{
+    'flowtype-errors': ?{
+      flowDir?: string,
+      stopOnExit?: any
+    }
+  },
+  options: any[]
+};

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,0 +1,62 @@
+/* @flow */
+
+import type { EslintContext } from './context';
+
+export class Script {
+  start: number;
+  code: string;
+  constructor(start: number, code: string = '') {
+    this.start = start;
+    this.code = code;
+  }
+
+  appendLine (line: string) {
+    return new Script(this.start, [this.code, line].join(''));
+  }
+}
+
+function parseCodeBlockLine(line, { scripts, script }) {
+  if (/<\/script>/.test(line)) {
+    scripts.push(script);
+    return { scripts };
+  }
+
+  return { scripts, script: script.appendLine(line) };
+}
+
+function parseHtmlBlockLine(line, idx, { scripts }) {
+  if (/<script>/.test(line)) {
+    return { scripts, script: new Script(idx + 1) };
+  }
+
+  return { scripts };
+}
+
+function parseLine(state, line, idx) {
+  if (state.script) {
+    return parseCodeBlockLine(line, state);
+  }
+
+  return parseHtmlBlockLine(line, idx, state);
+}
+
+function extractHtmlScripts(code) {
+  const lines = code.match(/[^\r\n]*[\r\n]+/g);
+
+  const res = lines.reduce(parseLine, { scripts: [] });
+  return res.scripts;
+}
+
+function isHtmlLike(context): boolean {
+  return /(\.html)|(\.vue)$/.test(context.getFilename());
+}
+
+export function getScripts(context: EslintContext): [Script] {
+  const code = context.getSourceCode().getText();
+
+  if (isHtmlLike(context)) {
+    return extractHtmlScripts(code);
+  }
+
+  return [ new Script(0, code) ];
+}

--- a/test/__snapshots__/format.spec.js.snap
+++ b/test/__snapshots__/format.spec.js.snap
@@ -122,6 +122,18 @@ exports[`Check codebases run-all-flowdir - eslint should give expected output 1`
 "
 `;
 
+exports[`Check codebases run-all-vue - eslint should give expected output 1`] = `
+"
+/home/ladoch/Projects/lxmx/eslint-plugin-flowtype-errors/test/codebases/run-all-vue/example.vue
+   4:10  error  string: This type is incompatible with the expected return type of 'boolean'. See line 3  flowtype-errors/show-errors
+   7:6   error  x: Could not resolve name                                                                 flowtype-errors/show-errors
+  14:14  error  string: The operand of an arithmetic operation must be a number                           flowtype-errors/show-errors
+
+✖ 3 problems (3 errors, 0 warnings)
+
+"
+`;
+
 exports[`Format 1.example.js - should have expected properties 1`] = `
 Array [
   Object {

--- a/test/codebases/run-all-vue/.flowconfig
+++ b/test/codebases/run-all-vue/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+all=true

--- a/test/codebases/run-all-vue/example.vue
+++ b/test/codebases/run-all-vue/example.vue
@@ -1,0 +1,22 @@
+
+<template>
+  <span>Test string</span>
+</template>
+
+<script>
+/* @flow */
+
+function test(x: string): boolean {
+  return 'string';
+}
+
+test(x);
+
+function square(x): number {
+  return x * x;
+}
+
+function incorrectSquare(x): number {
+  return x * 'x';
+}
+</script>

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -59,7 +59,7 @@ describe('Format', () => {
 const ESLINT_PATH = path.resolve('./node_modules/eslint/bin/eslint.js');
 
 function runEslint(cwd) {
-  const result = spawnSync(ESLINT_PATH, ['**/*.js'], { cwd });
+  const result = spawnSync(ESLINT_PATH, ['**/*.js', '**/*.vue'], { cwd });
   result.stdout = result.stdout && result.stdout.toString();
   result.stderr = result.stderr && result.stderr.toString();
   return result;
@@ -71,6 +71,7 @@ const codebases = [
   'no-flow-pragma',
   'project-1',
   'run-all',
+  'run-all-vue',
   'run-all-flowdir',
   'coverage-ok',
   'coverage-ok2',
@@ -101,7 +102,10 @@ const eslintConfig = enforceMinCoverage => `
   };
 
   module.exports = {
-    parser: 'babel-eslint',
+    parser: 'vue-eslint-parser',
+    parserOptions: {
+      parser: 'babel-eslint',
+    },
     root: true, // Make ESLint ignore configuration files in parent folders
     env: {
       node: true,


### PR DESCRIPTION
I as developer
When I create a Vue.js component
I want to be able to use the `eslint-plugin-flowtype-errors` without [html](https://github.com/BenoitZugmeyer/eslint-plugin-html) plugin
So that I can use it together with the [vue](https://github.com/vuejs/eslint-plugin-vue) plugin

**Tech:**

The [vue](https://github.com/vuejs/eslint-plugin-vue) plugin is incompatible with the [html](https://github.com/BenoitZugmeyer/eslint-plugin-html) plugin, according to the [#224](https://github.com/vuejs/eslint-plugin-vue/issues/224) and [#10](https://github.com/mysticatea/vue-eslint-parser/issues/10), therefore we have to implement extraction of JS code from `<script>` blocks in the `eslint-plugin-flowtype-errors` plugin itself.