### PR TITLE
New config lookup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ test_script:
   - node --version
   - yarn -V
   - yarn test
-  - yarn spec-win
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "prettier": "prettier --single-quote --write \"./src/*.js\"",
     "preversion": "npm run build",
     "spec": "npm run build && jest test/format.spec.js",
-    "spec-win": "npm run build && jest",
     "test": "flow && npm run lint && npm run spec"
   },
   "repository": {
@@ -37,6 +36,7 @@
   ],
   "dependencies": {
     "babel-runtime": "^6.26.0",
+    "find-up": "^3.0.0",
     "slash": "^2.0.0"
   },
   "devDependencies": {
@@ -63,6 +63,7 @@
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-vue": "^4.5.0",
+    "execa": "^0.10.0",
     "flow-bin": "^0.73.0",
     "jest-cli": "^23.0.0",
     "prettier": "^1.12.1",

--- a/src/collect.js
+++ b/src/collect.js
@@ -230,6 +230,7 @@ function spawnFlow(
     getFlowBin(),
     [mode, '--json', `--root=${root}`, filepath, ...extraOptions],
     {
+      cwd: root,
       input,
       encoding: 'utf-8'
     }

--- a/src/get-program.js
+++ b/src/get-program.js
@@ -5,17 +5,16 @@ type Pos = {
   column: number
 };
 
-type Loc = {
+export type Loc = {
   start: Pos,
   end: Pos
 };
 
-type Program = { text: string, loc: Loc, offset: Pos };
+export type Program = { text: string, loc: Loc, offset: Pos };
 
-export default function( source: Object, node: Object ): ?Program {
-
+export default function(source: Object, node: Object): ?Program {
   // Ignore if body is empty.
-  if ( node.body.length === 0 ) {
+  if (node.body.length === 0) {
     return;
   }
 
@@ -27,17 +26,20 @@ export default function( source: Object, node: Object ): ?Program {
   // With babel-eslint, program.loc.start.column is always 0,
   // workaround it by using the first node of the body to get the offset.
 
-  if ( comments0 ) {
-    start = node.range[0] < comments0.range[0] ? {
-      line: body0.loc.start.line,
-      column: body0.loc.start.column
-    } : {
-      line: comments0.loc.start.line,
-      column: comments0.loc.start.column
-    };
+  if (comments0) {
+    start =
+      node.range[0] < comments0.range[0]
+        ? {
+            line: body0.loc.start.line,
+            column: body0.loc.start.column
+          }
+        : {
+            line: comments0.loc.start.line,
+            column: comments0.loc.start.column
+          };
     range = [
-      Math.min( node.range[0], comments0.range[0] ),
-      Math.max( node.range[1], node.comments[node.comments.length - 1].range[1] )
+      Math.min(node.range[0], comments0.range[0]),
+      Math.max(node.range[1], node.comments[node.comments.length - 1].range[1])
     ];
   } else {
     start = {
@@ -48,7 +50,7 @@ export default function( source: Object, node: Object ): ?Program {
   }
 
   return {
-    text: source.text.slice( range[0], range[1] ),
+    text: source.text.slice(range[0], range[1]),
     loc: {
       start,
       end: start

--- a/src/index.js
+++ b/src/index.js
@@ -2,45 +2,83 @@
 
 import path from 'path';
 import fs from 'fs';
+// $FlowIgnore
+import findUp from 'find-up';
 import {
   type CollectOutputElement,
   FlowSeverity,
   collect,
   coverage
 } from './collect';
-import getProgram from './get-program';
+import getProgram, { type Program, type Loc } from './get-program';
 
 type EslintContext = {
-  getAllComments: Function,
-  getFilename: Function,
-  getSourceCode: Function,
-  report: Function,
+  getAllComments: () => { value: string }[],
+  getFilename: () => string,
+  getSourceCode: () => Object,
+  report: ({ loc: Loc, message: string }) => void,
   settings: ?{
     'flowtype-errors': ?{
-      flowDir?: string,
       stopOnExit?: any
     }
   },
   options: any[]
 };
 
-let runOnAllFiles;
+type Info = {
+  flowDir: string,
+  program: Program
+};
 
-function hasFlowPragma(source) {
-  return source.getAllComments().some(comment => /@flow/.test(comment.value));
-}
+const DEFAULT_LOC = {
+  start: {
+    line: 1,
+    column: 0
+  },
+  end: {
+    line: 1,
+    column: 0
+  }
+};
 
-function lookupFlowDir(context: EslintContext): string {
-  const root = process.cwd();
-  const flowDirSetting: string =
-    (context.settings &&
-      context.settings['flowtype-errors'] &&
-      context.settings['flowtype-errors'].flowDir) ||
-    '.';
+function lookupInfo(
+  context: EslintContext,
+  source: Object,
+  node: Object
+): ?Info {
+  const flowconfigFile = findUp.sync('.flowconfig', {
+    cwd: path.dirname(context.getFilename())
+  });
 
-  return fs.existsSync(path.join(root, flowDirSetting, '.flowconfig'))
-    ? path.join(root, flowDirSetting)
-    : root;
+  if (flowconfigFile == null) {
+    const program = getProgram(source, node);
+    context.report({
+      loc: program ? program.loc : DEFAULT_LOC,
+      message: "Could not find '.flowconfig' file"
+    });
+    return null;
+  }
+
+  const flowDir = path.dirname(flowconfigFile);
+
+  const runOnAllFiles = fs
+    .readFileSync(flowconfigFile, 'utf8')
+    .includes('all=true');
+
+  const shouldRun =
+    runOnAllFiles ||
+    source.getAllComments().some(comment => /@flow/.test(comment.value));
+
+  const program = shouldRun && getProgram(source, node);
+
+  if (program) {
+    return {
+      flowDir,
+      program
+    };
+  }
+
+  return null;
 }
 
 function stopOnExit(context: EslintContext): boolean {
@@ -54,42 +92,28 @@ function stopOnExit(context: EslintContext): boolean {
 function errorFlowCouldNotRun(loc) {
   return {
     loc,
-    message:
-`Flow could not be run. Possible causes include:
+    message: `Flow could not be run. Possible causes include:
   * Running on 32-bit OS (https://github.com/facebook/flow/issues/2262)
   * Recent glibc version not available (https://github.com/flowtype/flow-bin/issues/49)
-  * FLOW_BIN environment variable ${process.env.FLOW_BIN ? 'set incorrectly' : 'not set'}
+  * FLOW_BIN environment variable ${
+    process.env.FLOW_BIN ? 'set incorrectly' : 'not set'
+  }
 .`
   };
 }
 
-function createFilteredErrorRule(filter: (CollectOutputElement) => any) {
+function createFilteredErrorRule(filter: CollectOutputElement => any) {
   return function showErrors(context: EslintContext) {
     return {
       Program(node: Object) {
         const source = context.getSourceCode();
-        const flowDir = lookupFlowDir(context);
+        const info = lookupInfo(context, source, node);
 
-        // Check to see if we should run on every file
-        if (runOnAllFiles === undefined) {
-          try {
-            runOnAllFiles = fs
-              .readFileSync(path.join(flowDir, '.flowconfig'))
-              .toString()
-              .includes('all=true');
-          } catch (err) {
-            runOnAllFiles = false;
-          }
-        }
-
-        if (runOnAllFiles === false && !hasFlowPragma(source)) {
+        if (!info) {
           return;
         }
 
-        const program = getProgram(source, node);
-        if ( !program ) {
-          return;
-        }
+        const { flowDir, program } = info;
 
         const collected = collect(
           program.text,
@@ -136,50 +160,53 @@ export default {
       return {
         Program(node: Object) {
           const source = context.getSourceCode();
+          const info = lookupInfo(context, source, node);
 
-          if (hasFlowPragma(source)) {
-            const program = getProgram(source, node);
-            if ( !program ) {
-              return;
-            }
+          if (!info) {
+            return;
+          }
 
-            const res = coverage(
-              program.text,
-              lookupFlowDir(context),
-              stopOnExit(context),
-              context.getFilename()
-            );
+          const { flowDir, program } = info;
 
-            if (res === true) {
-              return;
-            }
+          const res = coverage(
+            program.text,
+            flowDir,
+            stopOnExit(context),
+            context.getFilename()
+          );
 
-            if (res === false) {
-              context.report(errorFlowCouldNotRun(program.loc));
-              return;
-            }
+          if (res === true) {
+            return;
+          }
 
-            const requiredCoverage = context.options[0];
-            const { coveredCount, uncoveredCount } = res;
+          if (res === false) {
+            context.report(errorFlowCouldNotRun(program.loc));
+            return;
+          }
 
-            /* eslint prefer-template: 0 */
-            const percentage = Number(
-              Math.round(
-                coveredCount / (coveredCount + uncoveredCount) * 10000
-              ) + 'e-2'
-            );
+          const requiredCoverage = context.options[0];
+          const { coveredCount, uncoveredCount } = res;
 
-            if (percentage < requiredCoverage) {
-              context.report({
-                loc: program.loc,
-                message: `Expected coverage to be at least ${requiredCoverage}%, but is: ${percentage}%`
-              });
-            }
+          /* eslint prefer-template: 0 */
+          const percentage = Number(
+            Math.round(coveredCount / (coveredCount + uncoveredCount) * 10000) +
+              'e-2'
+          );
+
+          if (percentage < requiredCoverage) {
+            context.report({
+              loc: program.loc,
+              message: `Expected coverage to be at least ${requiredCoverage}%, but is: ${percentage}%`
+            });
           }
         }
       };
     },
-    'show-errors': createFilteredErrorRule(({ level }) => level !== FlowSeverity.Warning),
-    'show-warnings': createFilteredErrorRule(({ level }) => level === FlowSeverity.Warning)
+    'show-errors': createFilteredErrorRule(
+      ({ level }) => level !== FlowSeverity.Warning
+    ),
+    'show-warnings': createFilteredErrorRule(
+      ({ level }) => level === FlowSeverity.Warning
+    )
   }
 };

--- a/test/codebases/column-offset/.flowconfig
+++ b/test/codebases/column-offset/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/coverage-fail/.flowconfig
+++ b/test/codebases/coverage-fail/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/coverage-fail2/.flowconfig
+++ b/test/codebases/coverage-fail2/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/coverage-ok/.flowconfig
+++ b/test/codebases/coverage-ok/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/coverage-ok2/.flowconfig
+++ b/test/codebases/coverage-ok2/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/flow-pragma-1/.flowconfig
+++ b/test/codebases/flow-pragma-1/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/flow-pragma-2/.flowconfig
+++ b/test/codebases/flow-pragma-2/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/html-support/.flowconfig
+++ b/test/codebases/html-support/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/no-flow-pragma/.flowconfig
+++ b/test/codebases/no-flow-pragma/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/test/codebases/project-1/.flowconfig
+++ b/test/codebases/project-1/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-.*/node_modules/.*
-.*/git/.*
-.*/test/codebases/.*
-.*/test/.*\.example\.js
-
 [options]
-suppress_comment=.*\\$FlowIgnore
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,7 +1390,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.5:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
@@ -1953,6 +1953,18 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -2152,6 +2164,12 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -3308,6 +3326,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -3739,15 +3764,31 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 parse-glob@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
As discussed in #124, I'm proposing a change in the way we look for `.flowconfig`, to allow for monorepo folder structure.

### Breaking change 

- Removed `flowDir` setting 
- Starting on each file, look upwards for a `.flowconfig` file. That becames the root.

### Other changes 

- Refactoring and ran `prettier`
- Removed `spec-win` script (tested on Windows that `spec` works just fine)
- Use `execa` instead of `cross-spawn` in tests (returns a promise allowing for async tests) 

### TODO 

- Optimize lookup?
- Update README
- Update CHANGELOG

Note: `spawn` for some reason is very slow on NodeJS 10 in Windows. That explains the error in AppVeyor. But also means I can't test locally for now. Waiting for Travis instead...