### PR TITLE
Fix Flow >= v0.71 on Windows

### DIFF
--- a/src/collect.js
+++ b/src/collect.js
@@ -226,6 +226,14 @@ function spawnFlow(
     return true;
   }
 
+  /**
+   * Workaround for Windows bug: https://github.com/facebook/flow/issues/6834
+   * Starting the Flow server before running `check-contents` prevents Flow from hanging.
+   */
+  if (process.platform === 'win32') {
+    childProcess.spawnSync(getFlowBin(), ['start', root]);
+  }
+
   const child = childProcess.spawnSync(
     getFlowBin(),
     [mode, '--json', `--root=${root}`, filepath, ...extraOptions],

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -5,7 +5,7 @@ import { readFileSync, writeFileSync, unlinkSync } from 'fs';
 import execa from 'execa';
 import { collect } from '../src/collect';
 
-jest.setTimeout(10000);
+jest.setTimeout(process.platform === 'win32' ? 30000 : 10000);
 
 const testFilenames = [
   '1.example.js',


### PR DESCRIPTION
Starting in Flow v0.71, Flow will hang forever on Windows when a Flow server is started with `flow check-contents` (see facebook/flow#6834).

This fix prevents Flow from hanging by manually starting the Flow server with `flow start` before the `flow check-contents` call.

Fixes #156