### PR TITLE
Fix formatting the path of local libdef files

### DIFF
--- a/src/collect.js
+++ b/src/collect.js
@@ -142,7 +142,7 @@ function formatSeePath(
     return '??';
   }
 
-  return loc.type === 'LibFile'
+  return loc.type === 'LibFile' && !loc.source.startsWith(root)
     ? `https://github.com/facebook/flow/blob/v${flowVersion}/lib/${pathModule.basename(
         loc.source
       )}#L${loc.start.line}`

--- a/test/__snapshots__/format.spec.js.snap
+++ b/test/__snapshots__/format.spec.js.snap
@@ -89,6 +89,17 @@ exports[`Check codebases html-support - eslint should give expected output 1`] =
 "
 `;
 
+exports[`Check codebases libdefs - eslint should give expected output 1`] = `
+"
+./example.js
+  4:8   error  Cannot call \`add\` with \`'2'\` bound to \`b\` because string is incompatible with number (see ./flow-typed/libdef.js:1)                                  flowtype-errors/show-errors
+  6:21  error  Cannot assign \`Date.now()\` to \`str\` because number (see https://github.com/facebook/flow/blob/v0.95.1/lib/core.js#L405) is incompatible with string  flowtype-errors/show-errors
+
+✖ 2 problems (2 errors, 0 warnings)
+
+"
+`;
+
 exports[`Check codebases no-flow-pragma - eslint should give expected output 1`] = `""`;
 
 exports[`Check codebases project-1 - eslint should give expected output 1`] = `

--- a/test/codebases/libdefs/.flowconfig
+++ b/test/codebases/libdefs/.flowconfig
@@ -1,0 +1,4 @@
+[options]
+esproposal.class_static_fields=enable
+esproposal.class_instance_fields=enable
+esproposal.export_star_as=enable

--- a/test/codebases/libdefs/example.js
+++ b/test/codebases/libdefs/example.js
@@ -1,0 +1,6 @@
+/**
+ * @flow
+ */
+add(1, '2'); // add() is from the libdef
+
+const str: string = Date.now();

--- a/test/codebases/libdefs/flow-typed/libdef.js
+++ b/test/codebases/libdefs/flow-typed/libdef.js
@@ -1,0 +1,1 @@
+declare function add(a: number, b: number): number;

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -75,6 +75,7 @@ const codebases = [
   'flow-pragma-1',
   'flow-pragma-2',
   'html-support',
+  'libdefs',
   'no-flow-pragma',
   'project-1',
   'run-all',


### PR DESCRIPTION
This fixes a bug where all libdef files were considered native Flow libdefs, so they were rendered as a URL to the Flow repo. Now, local libdef paths are properly rendered as a relative path to the local file.